### PR TITLE
Add jsDelivr CDN

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -22,6 +22,10 @@ Two ways.
 
 - links
 ```html
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.css">
+  
+  <script src="https://cdn.jsdelivr.net/npm/gitalk@1/dist/gitalk.min.js"></script>
+  <!-- or -->
   <link rel="stylesheet" href="https://unpkg.com/gitalk/dist/gitalk.css">
   
   <script src="https://unpkg.com/gitalk/dist/gitalk.min.js"></script>


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/gitalk) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can instantly serve any project from npm with zero config and offers a large network and better reliability.
