### PR TITLE
feat: add react-dom render optional callback support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ class Gitalk {
     this.options = options
   }
 
-  render (container) {
+  render (container, callback) {
     let node = null
     container = container || this.options.container
 
@@ -21,7 +21,11 @@ class Gitalk {
       node = container
     }
 
-    return render(<GitalkComponent options={this.options}/>, node)
+    if (!callback) {
+      callback = () => {}
+    }
+
+    return render(<GitalkComponent options={this.options}/>, node, callback)
   }
 }
 


### PR DESCRIPTION
I add react-dom [render optional callback](https://reactjs.org/docs/react-dom.html#render) support.
Now we can do something after gitalk is mounted.

like that:
```js
const gitalk = new Gitalk({
  clientID: 'GitHub Application Client ID',
  clientSecret: 'GitHub Application Client Secret',
  repo: 'GitHub repo',
  owner: 'GitHub repo owner',
  admin: ['GitHub repo owner and collaborators, only these guys can initialize github issues'],
  id: location.pathname,      // Ensure uniqueness and length less than 50
  distractionFreeMode: false  // Facebook-like distraction free mode
})

gitalk.render('gitalk-container', () => {
   // add event listener or do something
})
```