### PR TITLE
chore: update comment style

### DIFF
--- a/src/component/avatar.jsx
+++ b/src/component/avatar.jsx
@@ -2,6 +2,6 @@ import React from 'react'
 
 export default ({ src, className, alt }) => (
   <div className={`gt-avatar ${className}`}>
-    <img src={src} alt={alt}/>
+    <img src={src} alt={`@${alt}`}/>
   </div>
 )

--- a/src/component/avatar.jsx
+++ b/src/component/avatar.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-export default ({ src, className }) => (
+export default ({ src, className, alt }) => (
   <div className={`gt-avatar ${className}`}>
-    <img src={src} alt="头像"/>
+    <img src={src} alt={alt}/>
   </div>
 )

--- a/src/component/avatar.spec.js
+++ b/src/component/avatar.spec.js
@@ -16,5 +16,11 @@ describe('Avatar', function () {
       .find('img').prop('src')
     ).toEqual(src)
   })
+  it('set props alt', function () {
+    const alt = 'alt'
+    expect(shallow(<Avatar alt={alt} />)
+      .find('img').prop('alt')
+    ).toEqual(alt)
+  })
 })
 

--- a/src/component/avatar.spec.js
+++ b/src/component/avatar.spec.js
@@ -20,7 +20,7 @@ describe('Avatar', function () {
     const alt = 'alt'
     expect(shallow(<Avatar alt={alt} />)
       .find('img').prop('alt')
-    ).toEqual(alt)
+    ).toEqual(`@${alt}`)
   })
 })
 

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -62,7 +62,7 @@ export default class Comment extends Component {
         <Avatar
           className="gt-comment-avatar"
           src={comment.user && comment.user.avatar_url}
-          alt={`@${comment.user && comment.user.login}`}
+          alt={comment.user && comment.user.login}
         />
 
         <div className="gt-comment-content">

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -67,6 +67,7 @@ export default class Comment extends Component {
 
         <div className="gt-comment-content">
           <div className="gt-comment-header">
+            <div className={`gt-comment-block-${user ? '2' : '1'}`} />
             <a
               className="gt-comment-username"
               href={comment.user && comment.user.html_url}

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -62,6 +62,7 @@ export default class Comment extends Component {
         <Avatar
           className="gt-comment-avatar"
           src={comment.user && comment.user.avatar_url}
+          alt={`@${comment.user && comment.user.login}`}
         />
 
         <div className="gt-comment-content">

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -86,7 +86,7 @@ export default class Comment extends Component {
             </span>
 
             {reactions && (
-              <a className="gt-comment-like" onClick={likeCallback}>
+              <a className="gt-comment-like" title="Like" onClick={likeCallback}>
                 {reactions.viewerHasReacted ? (
                   <Svg
                     className="gt-ico-heart"
@@ -107,12 +107,13 @@ export default class Comment extends Component {
               <a
                 href={comment.html_url}
                 className="gt-comment-edit"
+                title="Edit"
                 target="_blank"
               >
                 <Svg className="gt-ico-edit" name="edit" />
               </a>
             ) : (
-              <a className="gt-comment-reply" onClick={replyCallback}>
+              <a className="gt-comment-reply" title="Reply" onClick={replyCallback}>
                 <Svg className="gt-ico-reply" name="reply" />
               </a>
             )}

--- a/src/component/comment.spec.js
+++ b/src/component/comment.spec.js
@@ -29,6 +29,7 @@ describe('Comment', function () {
     expect(wrapper.find('.gt-comment-date').text()).toEqual(expect.stringMatching(/ago$/))
     expect(wrapper.find('.gt-comment-body').render().html()).toEqual(expect.stringContaining(comment.body_html))
     expect(wrapper.find('.gt-comment-like')).toHaveLength(0)
+    expect(wrapper.find('.gt-comment-block-1')).toHaveLength(1)
   })
 
   it('render with user but isn\'t creator', function () {
@@ -38,6 +39,7 @@ describe('Comment', function () {
     }
     const wrapper = shallow(<Comment {...props} />)
     expect(wrapper.find('.gt-comment-edit')).toHaveLength(0)
+    expect(wrapper.find('.gt-comment-block-2')).toHaveLength(1)
   })
 
   it('render with user is creator', function () {
@@ -47,6 +49,7 @@ describe('Comment', function () {
     }
     const wrapper = shallow(<Comment {...props} />)
     expect(wrapper.find('.gt-comment-edit')).toHaveLength(1)
+    expect(wrapper.find('.gt-comment-block-2')).toHaveLength(1)
   })
 
   it('render with creator isn\'t admin', function () {

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -595,7 +595,7 @@ class GitalkComponent extends Component {
     return (
       <div className="gt-header" key="header">
         {user ?
-          <Avatar className="gt-header-avatar" src={user.avatar_url} /> :
+          <Avatar className="gt-header-avatar" src={user.avatar_url} alt={`@${user.login}`} /> :
           <a className="gt-avatar-github" onMouseDown={this.handleLogin}>
             <Svg className="gt-ico-github" name="github"/>
           </a>

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -595,7 +595,7 @@ class GitalkComponent extends Component {
     return (
       <div className="gt-header" key="header">
         {user ?
-          <Avatar className="gt-header-avatar" src={user.avatar_url} alt={`@${user.login}`} /> :
+          <Avatar className="gt-header-avatar" src={user.avatar_url} alt={user.login} /> :
           <a className="gt-avatar-github" onMouseDown={this.handleLogin}>
             <Svg className="gt-ico-github" name="github"/>
           </a>

--- a/src/style/index.styl
+++ b/src/style/index.styl
@@ -387,6 +387,14 @@ $gt-size-avatar-mobi := em(32px)
       margin-bottom: em(8px)
       font-size: em(14px)
       position: relative
+    &-block-1
+      float: right
+      height: em(22px)
+      width: em(32px)
+    &-block-2
+      float: right
+      height: em(22px)
+      width: em(64px)
     &-username
       font-weight: 500
       color: $gt-color-main


### PR DESCRIPTION
#### 该PR主要包含以下内容：
1.将评论区所有头像的alt属性由“头像”改为“@用户名”。
2.修复当用户名过长时文字会被右上角的图标（喜欢，编辑，回复）盖住的问题。
3.为图标（喜欢，编辑，回复）添加了title属性以提高用户体验。

```bash
jest
 PASS  src\__tests__\util.test.js
 PASS  src\component\avatar.spec.js
 PASS  src\component\svg.spec.js
 PASS  src\component\button.spec.js
 PASS  src\component\comment.spec.js
 PASS  src\component\action.spec.js
 PASS  src\__tests__\gitalk.test.js

Test Suites: 7 passed, 7 total
Tests:       30 passed, 30 total
Snapshots:   0 total
Time:        7.555s
Ran all test suites.
```