### PR TITLE
add id for comments item

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,12 @@
 .DS_Store
 
 .vscode
+.idea
+*.ipr
+*.iws
+*.iml
+.github
+node_modules
 
 npm-debug.log
 node_modules

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,15 @@
 
 Gitalk is a modern comment component based on GitHub Issue and Preact.
 
+## 分支self-talking特点
+
+- 非管理员用户只能点赞
+![](https://cdn.jsdelivr.net/gh/removeif/blog_image/img/2019/20191213091645.png)
+- 管理员用户还是原来的界面
+![](https://cdn.jsdelivr.net/gh/removeif/blog_image/img/2019/20191213091620.png)
+- 非登录时显示
+![](https://cdn.jsdelivr.net/gh/removeif/blog_image/img/2019/20191213091537.png)
+
 ## Features
 
 - Authentication with github account

--- a/readme.md
+++ b/readme.md
@@ -5,7 +5,8 @@
 Gitalk is a modern comment component based on GitHub Issue and Preact.
 
 ## 分支self-talking特点
-
+- [分支](https://github.com/removeif/gitalk/tree/self-talking)
+- [在线预览](https://removeif.github.io/self-talking/)
 - 非管理员用户只能点赞
 ![](https://cdn.jsdelivr.net/gh/removeif/blog_image/img/2019/20191213091645.png)
 - 管理员用户还是原来的界面

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -58,7 +58,7 @@ export default class Comment extends Component {
     }
 
     return (
-      <div className={`gt-comment ${isAdmin ? 'gt-comment-admin' : ''}`}>
+      <div className={`gt-comment ${isAdmin ? 'gt-comment-admin' : ''}`} id={`${comment.html_url.split('#')[1]}`}>
         <Avatar
           className="gt-comment-avatar"
           src={comment.user && comment.user.avatar_url}


### PR DESCRIPTION
诉求：博客中最新评论跳转时，需要跳转到对应的评论处
增加一个id可以方便利用
博客：https://removeif.github.io/
