### PR TITLE
fix: GitHub 访问不稳定，大概率加载不出头像,then 加载默认头像

### DIFF
--- a/src/component/avatar.jsx
+++ b/src/component/avatar.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
-export default ({ src, className, alt }) => (
+export default ({ src, className, alt,onError }) => (
   <div className={`gt-avatar ${className}`}>
-    <img src={src} alt={`@${alt}`}/>
+    <img src={src} alt={`@${alt}`} onError={onError} />
   </div>
 )

--- a/src/component/avatar.jsx
+++ b/src/component/avatar.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 
-export default ({ src, className, alt,onError }) => (
+export default ({ src, className, alt, onError }) => (
   <div className={`gt-avatar ${className}`}>
     <img src={src} alt={`@${alt}`} onError={onError} />
   </div>

--- a/src/component/avatar.spec.js
+++ b/src/component/avatar.spec.js
@@ -22,5 +22,11 @@ describe('Avatar', function () {
       .find('img').prop('alt')
     ).toEqual(`@${alt}`)
   })
+  it('set props onError', function () {
+    const onError = 'onError'
+    expect(shallow(<Avatar onError={onError} />)
+      .find('img').prop('onError')
+    ).toEqual(onError)
+  })
 })
 

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -42,6 +42,7 @@ export default class Comment extends Component {
       }, true)
     }
   }
+
   handleImageErrored(obj) {
 	obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
   }

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -44,7 +44,7 @@ export default class Comment extends Component {
   }
 
   handleImageErrored(obj) {
-	obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
+    obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
   }
   render () {
     const {
@@ -74,13 +74,14 @@ export default class Comment extends Component {
         reactionTotalCount = '100+'
       }
     }
+
     return (
       <div ref={node => { this.node = node }} className={`gt-comment ${isAdmin ? 'gt-comment-admin' : ''}`}>
         <Avatar
           className="gt-comment-avatar"
           src={comment.user && comment.user.avatar_url}
           alt={comment.user && comment.user.login}
-		  onError={this.handleImageErrored.bind(this)} 
+          onError={this.handleImageErrored.bind(this)} 
         />
 
         <div className="gt-comment-content">

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -42,7 +42,9 @@ export default class Comment extends Component {
       }, true)
     }
   }
-
+  handleImageErrored(obj) {
+	obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
+  }
   render () {
     const {
       comment,
@@ -71,13 +73,13 @@ export default class Comment extends Component {
         reactionTotalCount = '100+'
       }
     }
-
     return (
       <div ref={node => { this.node = node }} className={`gt-comment ${isAdmin ? 'gt-comment-admin' : ''}`}>
         <Avatar
           className="gt-comment-avatar"
           src={comment.user && comment.user.avatar_url}
           alt={comment.user && comment.user.login}
+		  onError={this.handleImageErrored.bind(this)} 
         />
 
         <div className="gt-comment-content">

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -612,7 +612,7 @@ class GitalkComponent extends Component {
 	obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
   }
   header () {
-    const { user, comment, isCreating, previewHtml, isPreview,ImageError } = this.state
+    const { user, comment, isCreating, previewHtml, isPreview } = this.state
     return (
       <div className="gt-header" key="header">
         {user ?

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -43,7 +43,7 @@ class GitalkComponent extends Component {
     isPopupVisible: false,
     isInputFocused: false,
     isPreview: false,
-	
+
     isOccurError: false,
     errorMsg: '',
   }

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -582,8 +582,7 @@ class GitalkComponent extends Component {
       this.handleCommentCreate()
     }
   }
- 
-  
+
   initing () {
     return <div className="gt-initing">
       <i className="gt-loader"/>

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -607,8 +607,9 @@ class GitalkComponent extends Component {
       </div>
     )
   }
-   handleImageErrored(obj) {
-	obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
+
+  handleImageErrored(obj) {
+    obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
   }
   header () {
     const { user, comment, isCreating, previewHtml, isPreview } = this.state

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -43,7 +43,7 @@ class GitalkComponent extends Component {
     isPopupVisible: false,
     isInputFocused: false,
     isPreview: false,
-
+	
     isOccurError: false,
     errorMsg: '',
   }
@@ -582,7 +582,8 @@ class GitalkComponent extends Component {
       this.handleCommentCreate()
     }
   }
-
+ 
+  
   initing () {
     return <div className="gt-initing">
       <i className="gt-loader"/>
@@ -607,12 +608,15 @@ class GitalkComponent extends Component {
       </div>
     )
   }
+   handleImageErrored(obj) {
+	obj.target.src="https://cdn.jsdelivr.net/npm/gitalk@1/src/assets/icon/github.svg";
+  }
   header () {
-    const { user, comment, isCreating, previewHtml, isPreview } = this.state
+    const { user, comment, isCreating, previewHtml, isPreview,ImageError } = this.state
     return (
       <div className="gt-header" key="header">
         {user ?
-          <Avatar className="gt-header-avatar" src={user.avatar_url} alt={user.login} /> :
+          <Avatar className="gt-header-avatar" src={user.avatar_url} alt={user.login} onError={this.handleImageErrored.bind(this)} />:
           <a className="gt-avatar-github" onMouseDown={this.handleLogin}>
             <Svg className="gt-ico-github" name="github"/>
           </a>


### PR DESCRIPTION
#354 
# 测试方法

测试页面：[Test Page](https://mhuig.github.io/guestbook/)

浏览器F12开发者工具，修改img src为不可达url即可完成测试

## 测试正常:
![Pass](https://cdn.jsdelivr.net/gh/MHuiG/imgbed/data/20200219180014.png)

## 测试模拟GitHub 访问不稳定 加载默认头像:
![Error](https://cdn.jsdelivr.net/gh/MHuiG/imgbed/data/20200219180028.png)
