### PR TITLE
fix: css

### DIFF
--- a/dist/gitalk.css
+++ b/dist/gitalk.css
@@ -1001,12 +1001,7 @@
   -webkit-box-flex: 1;
       -ms-flex: 1;
           flex: 1;
-  margin-left: 1.25em;
-}
-@media (max-width: 479px) {
-  .gt-container .gt-header-comment {
-    margin-left: 0.875em;
-  }
+  width: 100%;
 }
 .gt-container .gt-header-textarea {
   padding: 0.75em;


### PR DESCRIPTION
## 修复文本特别多的时候，预览会被挤出框架外  

### before  
![image](https://user-images.githubusercontent.com/29943110/90238557-bd249100-de58-11ea-8a7e-f52b7b81811c.png)  

### after  
![image](https://user-images.githubusercontent.com/29943110/90238481-a2eab300-de58-11ea-9827-5150b20e31b1.png)  

