### PR TITLE
Add "noopener" and "noreferrer" rel links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 node_js:
   - stable
-before_script:
+install:
   # not compatible webpack@3.1.0 and extract-text-webpack-plugin@2.1.2
   - npm install --force
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
   - stable
+before_script:
+  # not compatible webpack@3.1.0 and extract-text-webpack-plugin@2.1.2
+  - npm install --force
 script:
   - npm run lint
   - npm run test

--- a/src/component/comment.jsx
+++ b/src/component/comment.jsx
@@ -127,6 +127,7 @@ export default class Comment extends Component {
                 className="gt-comment-edit"
                 title="Edit"
                 target="_blank"
+                rel="noopener noreferrer"
               >
                 <Svg className="gt-ico-edit" name="edit" />
               </a>

--- a/src/gitalk.jsx
+++ b/src/gitalk.jsx
@@ -639,7 +639,7 @@ class GitalkComponent extends Component {
             dangerouslySetInnerHTML={{ __html: previewHtml }}
           />
           <div className="gt-header-controls">
-            <a className="gt-header-controls-tip" href="https://guides.github.com/features/mastering-markdown/" target="_blank">
+            <a className="gt-header-controls-tip" href="https://guides.github.com/features/mastering-markdown/" target="_blank" rel="noopener noreferrer">
               <Svg className="gt-ico-tip" name="tip" text={this.i18n.t('support-markdown')}/>
             </a>
             {user && <Button
@@ -714,7 +714,7 @@ class GitalkComponent extends Component {
       <div className="gt-meta" key="meta" >
         <span className="gt-counts" dangerouslySetInnerHTML={{
           __html: this.i18n.t('counts', {
-            counts: `<a class="gt-link gt-link-counts" href="${issue && issue.html_url}" target="_blank">${cnt}</a>`,
+            counts: `<a class="gt-link gt-link-counts" href="${issue && issue.html_url}" target="_blank" rel="noopener noreferrer">${cnt}</a>`,
             smart_count: cnt
           })
         }}/>
@@ -727,7 +727,7 @@ class GitalkComponent extends Component {
               <a className="gt-action gt-action-login" onClick={this.handleLogin}>{this.i18n.t('login-with-github')}</a>
             }
             <div className="gt-copyright">
-              <a className="gt-link gt-link-project" href="https://github.com/gitalk/gitalk" target="_blank">Gitalk</a>
+              <a className="gt-link gt-link-project" href="https://github.com/gitalk/gitalk" target="_blank" rel="noopener noreferrer">Gitalk</a>
               <span className="gt-version">{GT_VERSION}</span>
             </div>
           </div>


### PR DESCRIPTION
Add "noopener" and "noreferrer" rel links because links to cross-origin destinations are unsafe on legacy browsers.
When I use gitalk, the above recommendations become a warning every time in google lighthouse results.

Refs: https://web.dev/external-anchors-use-rel-noopener/?utm_source=lighthouse&utm_medium=lr

And also, not compatible webpack@3.1.0 and extract-text-webpack-plugin@2.1.2, so I want to change travis.yml  to npm force install because of CI failed.